### PR TITLE
Refactor resize rootdisk

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -17,7 +17,7 @@ BUILD_PATH="/build"
 # config vars for the root file system
 ROOTFS_TAR="rootfs-armhf.tar.gz"
 ROOTFS_TAR_PATH="${BUILD_RESULT_PATH}/${ROOTFS_TAR}"
-ROOTFS_TAR_VERSION="v0.6"
+ROOTFS_TAR_VERSION="v0.6.0"
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -17,7 +17,7 @@ BUILD_PATH="/build"
 # config vars for the root file system
 ROOTFS_TAR="rootfs-armhf.tar.gz"
 ROOTFS_TAR_PATH="${BUILD_RESULT_PATH}/${ROOTFS_TAR}"
-ROOTFS_TAR_VERSION="v0.5"
+ROOTFS_TAR_VERSION="v0.6"
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"

--- a/builder/files/etc/firstboot.d/10-resize-rootdisk
+++ b/builder/files/etc/firstboot.d/10-resize-rootdisk
@@ -1,6 +1,3 @@
-#!/bin/bash
-set -ex
-
 if ! [ -h /dev/disk/by-label/root ]; then
   echo "/dev/disk/by-label/root does not exist or is not a symlink. Don't know how to expand"
   return 0
@@ -51,6 +48,3 @@ set -e
 
 partprobe
 /sbin/resize2fs /dev/disk/by-label/root
-
-# do not resize after first resize again
-systemctl disable hypriot-resize-rootdisk.service

--- a/builder/files/lib/systemd/system/hypriot-resize-rootdisk.service
+++ b/builder/files/lib/systemd/system/hypriot-resize-rootdisk.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Resize root disk to maximum size
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/hypriot-resize-rootdisk
-
-[Install]
-WantedBy=multi-user.target

--- a/builder/files/lib/systemd/system/multi-user.target.wants/hypriot-resize-rootdisk.service
+++ b/builder/files/lib/systemd/system/multi-user.target.wants/hypriot-resize-rootdisk.service
@@ -1,1 +1,0 @@
-../hypriot-resize-rootdisk.service


### PR DESCRIPTION
__Only merge this PR when the os-rootfs is tagged with version 0.6 and the firstboot service is included!__
Depends on https://github.com/hypriot/os-rootfs/pull/7

This PR refactores the resize-root disk script to work with the firstboot service from the os-rootfs.