### PR TITLE
WIP: Add device-init

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "boxcutter/ubuntu1404"
 
-  config.vm.network "forwarded_port", guest: 2376, host: 2376
+  config.vm.network "forwarded_port", guest: 2376, host: 2376, auto_correct: true
   config.vm.synced_folder ".", "#{`pwd`.chomp}"
 
   config.vm.provider "vmware_fusion" do |v|

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -37,6 +37,7 @@ export KERNEL_VERSION="4.1.12"
 export DOCKER_ENGINE_VERSION="1.10.0-1"
 export DOCKER_COMPOSE_VERSION="1.6.0-27"
 export DOCKER_MACHINE_VERSION="0.4.1-72"
+export DEVICE_INIT_VERSION="0.0.14"
 
 # create build directory for assembling our image filesystem
 rm -rf ${BUILD_PATH}

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -53,7 +53,8 @@ proc /proc proc defaults 0 0
 apt-get install -y \
   "docker-hypriot=${DOCKER_ENGINE_VERSION}" \
   "docker-compose=${DOCKER_COMPOSE_VERSION}" \
-  "docker-machine=${DOCKER_MACHINE_VERSION}"
+  "docker-machine=${DOCKER_MACHINE_VERSION}" \
+  "device-init=${DEVICE_INIT_VERSION}"
 
 # enable Docker systemd service
 systemctl enable docker

--- a/builder/files/boot/device-init.yaml
+++ b/builder/files/boot/device-init.yaml
@@ -1,0 +1,2 @@
+# hostname for your HypriotOS device
+hostname: black-pearl

--- a/builder/test-integration/spec/hypriotos-image/base/firstboot_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/firstboot_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe file('/etc/hypriot-firstboot_not_to_be_run') do
   it { should be_file }
 end

--- a/builder/test-integration/spec/hypriotos-image/device-init_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/device-init_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe package('device-init') do
+  it { should be_installed }
+end
+
+describe command('dpkg -l device-init') do
+  its(:stdout) { should match /ii  device-init/ }
+  its(:stdout) { should match /0.0.14/ }
+  its(:exit_status) { should eq 0 }
+end
+
+describe file('/usr/local/bin/device-init') do
+  it { should be_file }
+  it { should be_mode 755 }
+  it { should be_owned_by 'root' }
+end
+
+describe command('device-init --version') do
+  its(:stdout) { should match /0.0.14/m }
+#  its(:stderr) { should match /^$/ }
+  its(:exit_status) { should eq 0 }
+end

--- a/builder/test-integration/spec/hypriotos-image/device-init_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/device-init_spec.rb
@@ -10,14 +10,19 @@ describe command('dpkg -l device-init') do
   its(:exit_status) { should eq 0 }
 end
 
+describe file('/boot/device-init.yaml') do
+  it { should be_file }
+  its(:content) { should match /hostname: / }
+end
+
 describe file('/usr/local/bin/device-init') do
   it { should be_file }
   it { should be_mode 755 }
   it { should be_owned_by 'root' }
 end
 
-describe command('device-init --version') do
-  its(:stdout) { should match /0.0.14/m }
-#  its(:stderr) { should match /^$/ }
-  its(:exit_status) { should eq 0 }
-end
+# describe command('device-init --version') do
+#   its(:stdout) { should match /0.0.14/m }
+# #  its(:stderr) { should match /^$/ }
+#   its(:exit_status) { should eq 0 }
+# end


### PR DESCRIPTION
Add [device-init](https://github.com/hypriot/device-init) to the SD-Card image to make the device configurable with an optional `/boot/device-init.yaml` file.

As of version 0.0.14 only the hostname can be customized on first boot.

Fixes #16 

Adding a default `/boot/device-init.yaml` so the `flash` script can update hostname in it.
