### PR TITLE
Fix UART console baudrate for Pi 3

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -50,6 +50,7 @@ echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgr
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)
 echo "
 hdmi_force_hotplug=1
+core_freq=250
 " > boot/config.txt
 
 # /etc/modules

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -45,7 +45,7 @@ apt-get install -y \
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 
 # boot/cmdline.txt
-echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup-enable=memory swapaccount=1 elevator=deadline rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
+echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup-enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
 
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)
 echo "

--- a/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
@@ -1,7 +1,13 @@
 describe file('/boot/cmdline.txt') do
   it { should be_file }
-  its(:content) { should match /console=tty1/ }
+  it { should be_mode 755 }
+  it { should be_owned_by 'root' }
+  its(:content) { should match /\+dwc_otg.lpm_enable=0/ }
+  its(:content) { should match /root=\/dev\/mmcblk0p2/ }
   its(:content) { should match /rootfstype=ext4/ }
   its(:content) { should match /cgroup-enable=memory/ }
   its(:content) { should match /swapaccount=1/ }
+  its(:content) { should match /elevator=deadline/ }
+  its(:content) { should match /fsck.repair=yes/ }
+  its(:content) { should match /rootwait/ }
 end

--- a/builder/test-integration/spec/hypriotos-image/cmdline_serial_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cmdline_serial_spec.rb
@@ -2,7 +2,7 @@ describe file('/boot/cmdline.txt') do
   it { should be_file }
   it { should be_mode 755 }
   it { should be_owned_by 'root' }
-  its(:content) { should match /\+dwc_otg.lpm_enable=0/ }
+  its(:content) { should match /console=tty1/ }
   its(:content) { should match /console=ttyAMA0,115200/ }
   its(:content) { should match /kgdboc=ttyAMA0,115200/ }
 end

--- a/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
@@ -1,0 +1,7 @@
+describe file('/boot/config.txt') do
+  it { should be_file }
+  it { should be_mode 755 }
+  it { should be_owned_by 'root' }
+  its(:content) { should match /^hdmi_force_hotplug=1/ }
+  its(:content) { should match /^core_freq=250/ }
+end


### PR DESCRIPTION
* Fix UART console for Pi 3 (fixes #32)
* Add fsck.repair=yes like in Raspbian LITE