### PR TITLE
Add comments for wlan0 for flash tool

### DIFF
--- a/builder/files/boot/device-init.yaml
+++ b/builder/files/boot/device-init.yaml
@@ -1,2 +1,8 @@
 # hostname for your HypriotOS device
 hostname: black-pearl
+# optional wireless network settings
+wifi:
+  interfaces:
+#     wlan0:
+#       ssid: "MyNetwork"
+#       password: "secret_password"


### PR DESCRIPTION
Add a comment block to set the wifi name and password with the flash tool. 
Having such a comment it is easier for user's to add their wifi settings manually as well.

Connects to hypriot/flash#58