### PR TITLE
Create os-release file on /boot folder

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -111,3 +111,4 @@ systemctl disable cluster-lab.service
 # set device label and version number
 echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
 echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
+cp /etc/os-release /boot/os-release

--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -10,3 +10,12 @@ describe file('/etc/os-release') do
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end
+
+describe file('/boot/os-release') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.5"/ }
+  its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
+  its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
+end


### PR DESCRIPTION
Now we do have a file with version infos on the DOS partition which is readable before flashing the image from Windows, Linux and OS X.