### PR TITLE
Enable UART console on Pi3

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -51,7 +51,7 @@ echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgr
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)
 echo "
 hdmi_force_hotplug=1
-core_freq=250
+enable_uart=1
 " > boot/config.txt
 
 # /etc/modules

--- a/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
@@ -3,5 +3,5 @@ describe file('/boot/config.txt') do
   it { should be_mode 755 }
   it { should be_owned_by 'root' }
   its(:content) { should match /^hdmi_force_hotplug=1/ }
-  its(:content) { should match /^core_freq=250/ }
+  its(:content) { should match /^enable_uart=1/ }
 end


### PR DESCRIPTION
There was a recent change in the Raspberry Pi boot supporting files (binary blobs)
how to initialize the UART device which is used for the UART console. For this reason
we can enable it easily with `enable_uart=1` in '/boot/config.txt'.

More details can be found in this blog post https://www.hackster.io/fvdbosch/uart-for-serial-console-or-hat-on-raspberry-pi-3-5be0c2