### PR TITLE
Fix startup of systemd-modules-load.service

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -57,7 +57,7 @@ enable_uart=1
 # /etc/modules
 echo "vchiq
 snd_bcm2835
-bcm2708-rng
+bmc2835_rng
 " >> /etc/modules
 
 # create /etc/fstab

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -57,7 +57,7 @@ enable_uart=1
 # /etc/modules
 echo "vchiq
 snd_bcm2835
-bmc2835_rng
+bcm2835_rng
 " >> /etc/modules
 
 # create /etc/fstab

--- a/builder/test-integration/spec/hypriotos-image/kernel_modules_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/kernel_modules_spec.rb
@@ -1,0 +1,10 @@
+Specinfra::Runner.run_command('modprobe snd_bcm2835')
+Specinfra::Runner.run_command('modprobe bcm2835_rng')
+
+describe kernel_module('snd_bcm2835') do
+  it { should be_loaded }
+end
+
+describe kernel_module('bcm2835_rng') do
+  it { should be_loaded }
+end


### PR DESCRIPTION
The module `bcm2708-rng` is missing in this release and causes a startup failure of 
`systemd-modules-load.service`, but we can switch to module 
`bcm2835_rng` to resolve this problem.