### PR TITLE
Use os-rootfs 0.8.6 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 default: build
 
 build:
+	docker build -t image-builder-rpi . || true
 	docker build -t image-builder-rpi .
 
 sd-image: build

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -15,7 +15,7 @@ BUILD_RESULT_PATH="/workspace"
 BUILD_PATH="/build"
 
 # config vars for the root file system
-HYPRIOT_OS_VERSION="v0.8.5"
+HYPRIOT_OS_VERSION="v0.8.6"
 ROOTFS_TAR="rootfs-armhf-raspbian-${HYPRIOT_OS_VERSION}.tar.gz"
 ROOTFS_TAR_PATH="${BUILD_RESULT_PATH}/${ROOTFS_TAR}"
 

--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -5,8 +5,9 @@ end
 describe file('/etc/os-release') do
   it { should be_file }
   it { should be_owned_by 'root' }
+  its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.5"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.6"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end
@@ -14,8 +15,9 @@ end
 describe file('/boot/os-release') do
   it { should be_file }
   it { should be_owned_by 'root' }
+  its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.5"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.6"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -36,8 +36,8 @@ describe "Root filesystem" do
     expect(stdout).to contain('^HYPRIOT_DEVICE="Raspberry Pi"$')
   end
 
-  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.8.5\"'" do
-    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.8.5"$')
+  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.8.6\"'" do
+    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.8.6"$')
   end
 
   if ENV.fetch('TRAVIS_TAG','') != ''


### PR DESCRIPTION
Use os-rootfs v0.8.6 to make /etc/os-release compatible w/ docker-machine

Resolves #79 
