### PR TITLE
Use empty daemon.json to make it compatible w/ docker-machine

### DIFF
--- a/builder/files/etc/docker/daemon.json
+++ b/builder/files/etc/docker/daemon.json
@@ -1,4 +1,2 @@
 {
-  "storage-driver": "overlay",
-  "hosts": ["fd://"]
 }

--- a/builder/test/image_spec.rb
+++ b/builder/test/image_spec.rb
@@ -55,4 +55,11 @@ describe "SD card image" do
     end
   end
 
+  context "Docker daemon config" do
+    let(:stdout) { run_mounted("cat /etc/docker/daemon.json").stdout }
+
+    it "Daemon config is empty" do
+      expect(stdout).to contain("{\n}\n\n")
+    end
+  end
 end


### PR DESCRIPTION
Is an empty /etc/docker/daemon.json and Docker engine still uses its defaults with overlay and local unix socket.

This makes docker-machine work with our SD image again until docker-machine is capable parsing and updating this daemon.json (docker/machine#3062)

Fixes #80 
