### PR TITLE
Use hypriot/image-builder base image to fix httpredir errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,4 @@
-FROM debian:jessie
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python-pip \
-    build-essential \
-    libguestfs-tools \
-    libncurses5-dev \
-    tree \
-    binfmt-support \
-    qemu \
-    qemu-user-static \
-    debootstrap \
-    kpartx \
-    lvm2 \
-    dosfstools \
-    zip \
-    unzip \
-    awscli \
-    ruby \
-    ruby-dev \
-    shellcheck \
-    --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN gem update --system && \
-    gem install --no-document serverspec
+FROM hypriot/image-builder:latest
 
 COPY builder/ /builder/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM hypriot/image-builder:latest
 
 RUN apt-get update && \
-    apt-get remove -y binfmt-support && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     binfmt-support \
+    qemu \
+    qemu-user-static \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM hypriot/image-builder:latest
 
+RUN apt-get update && \
+    apt-get remove -y binfmt-support && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    binfmt-support \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY builder/ /builder/
 
 # build sd card image

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 default: build
 
 build:
-	docker build -t image-builder-rpi . || true
 	docker build -t image-builder-rpi .
 
 sd-image: build


### PR DESCRIPTION
Use the Docker base image `hypriot/image-builder` from https://github.com/hypriot/image-builder repo to speed up builds at Travis and CircleCI and to avoid problems with httpredir.debian.org.

