### PR TITLE
Set storage driver overlay in service file

### DIFF
--- a/builder/files/etc/systemd/system/docker.service
+++ b/builder/files/etc/systemd/system/docker.service
@@ -9,7 +9,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/docker daemon
+ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver overlay
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -52,11 +52,24 @@ describe file('/lib/systemd/system/docker.socket') do
   it { should be_owned_by 'root' }
 end
 
+describe file('/etc/systemd/system/docker.service') do
+  it { should be_file }
+  it { should be_mode 644 }
+  it { should be_owned_by 'root' }
+  its(:content) { should match /ExecStart=\/usr\/bin\/docker daemon -H fd:\/\/ --storage-driver overlay/ }
+end
+
+describe file('/var/run/docker.sock') do
+  it { should be_socket }
+  it { should be_mode 660 }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'docker' }
+end
+
 describe file('/etc/default/docker') do
   it { should be_file }
   it { should be_mode 644 }
   it { should be_owned_by 'root' }
-#   its(:content) { should match /--storage-driver=overlay/ }
 end
 
 describe file('/var/lib/docker') do

--- a/builder/test/image_spec.rb
+++ b/builder/test/image_spec.rb
@@ -62,4 +62,12 @@ describe "SD card image" do
       expect(stdout).to contain("{\n}\n\n")
     end
   end
+
+  context "Docker service file" do
+    let(:stdout) { run_mounted("cat /etc/systemd/system/docker.service").stdout }
+
+    it "Daemon uses overlay storage driver" do
+      expect(stdout).to contain("--storage-driver overlay")
+    end
+  end
 end


### PR DESCRIPTION
Add the command line option `--storage-driver overlay` to the docker.service file instead of the daemon.json. Still compatible with docker-machine and using overlay as the storage driver even w/o docker-machine connection.

connects to #85 
