### PR TITLE
Update hypriot-cluster-lab 0.2.7

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -38,7 +38,7 @@ export DOCKER_ENGINE_VERSION="1.11.1-1"
 export DOCKER_COMPOSE_VERSION="1.7.1-38"
 export DOCKER_MACHINE_VERSION="0.4.1-72"
 export DEVICE_INIT_VERSION="0.1.5"
-export CLUSTER_LAB_VERSION="0.2.6-1"
+export CLUSTER_LAB_VERSION="0.2.7-1"
 
 # create build directory for assembling our image filesystem
 rm -rf ${BUILD_PATH}

--- a/builder/test-integration/spec/hypriotos-image/cluster_lab_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cluster_lab_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe command('dpkg -l hypriot-cluster-lab') do
   its(:stdout) { should match /ii  hypriot-cluster-lab/ }
-  its(:stdout) { should match /0.2.6/ }
+  its(:stdout) { should match /0.2.7/ }
   its(:exit_status) { should eq 0 }
 end
 


### PR DESCRIPTION
Install fixed hypriot-cluster-lab v0.2.7 with config in docker.service file instead of daemon.json.

connects to hypriot/cluster-lab#36
