### PR TITLE
Use docker-hypriot 1.11.1-1 package

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -84,7 +84,7 @@ apt-get install -y \
 
 # install hypriot packages for docker-tools
 apt-get install -y \
-  "docker-engine=${DOCKER_ENGINE_VERSION}" \
+  "docker-hypriot=${DOCKER_ENGINE_VERSION}" \
   "docker-compose=${DOCKER_COMPOSE_VERSION}" \
   "docker-machine=${DOCKER_MACHINE_VERSION}" \
   "device-init=${DEVICE_INIT_VERSION}"

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe package('docker-engine') do
+describe package('docker-hypriot') do
   it { should be_installed }
 end
 
-describe command('dpkg -l docker-engine') do
-  its(:stdout) { should match /ii  docker-engine/ }
+describe command('dpkg -l docker-hypriot') do
+  its(:stdout) { should match /ii  docker-hypriot/ }
   its(:stdout) { should match /1.11.1-1/ }
   its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
Due to naming conflicts switch back to docker-hypriot package for Docker 1.11.1.

connects to hypriot/build-pipeline#189
