### PR TITLE
Enable usage of the Raspberry Pi camera

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -147,6 +147,12 @@ hdmi_force_hotplug=1
 enable_uart=1
 " > boot/config.txt
 
+echo "# camera settings, see http://elinux.org/RPiconfig#Camera
+start_x=1
+disable_camera_led=1
+gpu_mem=128
+" >> boot/config.txt
+
 # /etc/modules
 echo "snd_bcm2835
 " >> /etc/modules

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -132,6 +132,9 @@ apt-get install -y \
   "linux-headers-${KERNEL_VERSION}-hypriotos-v7+" \
   "linux-headers-${KERNEL_VERSION}-hypriotos+"
 
+# add user pirate to group video (for using the Raspberry Pi camera)
+usermod -a -G video pirate
+
 # enable serial console
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 

--- a/builder/test-integration/spec/hypriotos-image/base/users_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/users_spec.rb
@@ -13,6 +13,7 @@ describe user('pirate') do
   it { should have_home_directory '/home/pirate' }
   it { should have_login_shell '/bin/bash' }
   it { should belong_to_group 'docker' }
+  it { should belong_to_group 'video' }
 end
 
 describe file('/etc/sudoers') do

--- a/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/config_txt_spec.rb
@@ -4,4 +4,7 @@ describe file('/boot/config.txt') do
   it { should be_owned_by 'root' }
   its(:content) { should match /^hdmi_force_hotplug=1/ }
   its(:content) { should match /^enable_uart=1/ }
+  its(:content) { should match /^start_x=1/ }
+  its(:content) { should match /^disable_camera_led=1/ }
+  its(:content) { should match /^gpu_mem=128/ }
 end


### PR DESCRIPTION
In order to use the Raspberry Pi camera without any further configuration, we just include the necessary settings in our default SD image. Resolves https://github.com/hypriot/image-builder-rpi/issues/108.

* Add user pirate to group video
* Add default settings for using the Pi camera

 Signed-off-by: Dieter Reuter <dieter.reuter@me.com>