### PR TITLE
Update os-rootfs 0.8.7

### DIFF
--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -7,7 +7,7 @@ describe file('/etc/os-release') do
   it { should be_owned_by 'root' }
   its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.6"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.7"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end
@@ -17,7 +17,7 @@ describe file('/boot/os-release') do
   it { should be_owned_by 'root' }
   its(:content) { should contain /ID=debian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.6"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v0.8.7"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -36,8 +36,8 @@ describe "Root filesystem" do
     expect(stdout).to contain('^HYPRIOT_DEVICE="Raspberry Pi"$')
   end
 
-  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.8.6\"'" do
-    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.8.6"$')
+  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.8.7\"'" do
+    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.8.7"$')
   end
 
   if ENV.fetch('TRAVIS_TAG','') != ''

--- a/versions.config
+++ b/versions.config
@@ -1,6 +1,6 @@
 # config vars for the root file system
-HYPRIOT_OS_VERSION="v0.8.6"
-ROOTFS_TAR_CHECKSUM="d1b9642317d5154ddfe5042b21232d10a036ff677cf100bcf916da81a5c811ad"
+HYPRIOT_OS_VERSION="v0.8.7"
+ROOTFS_TAR_CHECKSUM="dfe865cfce32ca0712bbe4402b5c5152fa05e9864d3b875507b1bdd9dc812979"
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"


### PR DESCRIPTION
Update to os-rootfs v0.8.7 to have `/sbin` et al in user pirate's PATH.

Connects to #107 
