### PR TITLE
Remove package libraspberrypi-doc_*_armhf.deb

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -128,7 +128,6 @@ apt-get install -y \
   "libraspberrypi0=${KERNEL_BUILD}" \
   "libraspberrypi-dev=${KERNEL_BUILD}" \
   "libraspberrypi-bin=${KERNEL_BUILD}" \
-  "libraspberrypi-doc=${KERNEL_BUILD}" \
   "linux-headers-${KERNEL_VERSION}-hypriotos-v7+" \
   "linux-headers-${KERNEL_VERSION}-hypriotos+"
 


### PR DESCRIPTION
This package is about 30 MByte in size and it seems we really don't need it.
So we just skip it for now and remove it from our SD image.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>