### PR TITLE
Update chroot-script.sh

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -136,7 +136,7 @@ usermod -a -G video pirate
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 
 # boot/cmdline.txt
-echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
+echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
 
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)
 echo "

--- a/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
@@ -6,6 +6,7 @@ describe file('/boot/cmdline.txt') do
   its(:content) { should match /root=\/dev\/mmcblk0p2/ }
   its(:content) { should match /rootfstype=ext4/ }
   its(:content) { should match /cgroup_enable=memory/ }
+  its(:content) { should match /cgroup_enable=cpuset/ }
   its(:content) { should match /swapaccount=1/ }
   its(:content) { should match /elevator=deadline/ }
   its(:content) { should match /fsck.repair=yes/ }


### PR DESCRIPTION
Per kubernetes/kubernetes#26038 this is needed to run kubelet on the RPi when installing https://github.com/kubernetes/kube-deploy/tree/master/docker-multinode. Would be nice to have this included by default since, I assume, this is a common use case.