### PR TITLE
Use docker-ce 17.06 edge

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -206,6 +206,7 @@ apt-get install -y \
 pip install docker-compose
 
 # set up Docker APT repository and install docker-engine package
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 apt-get install -y \
   --no-install-recommends \
   docker-ce

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -104,6 +104,8 @@ echo 'deb https://packagecloud.io/Hypriot/rpi/debian/ jessie main' > /etc/apt/so
 # set up hypriot schatzkiste repository for generic packages
 echo 'deb https://packagecloud.io/Hypriot/Schatzkiste/debian/ jessie main' >> /etc/apt/sources.list.d/hypriot.list
 
+# set up Docker CE repository
+echo 'deb [arch=armhf] https://download.docker.com/linux/debian jessie edge' > /etc/apt/sources.list.d/docker.list
 
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
 get_gpg "${RPI_ORG_FPR}" "${RPI_ORG_KEY_URL}"
@@ -204,7 +206,9 @@ apt-get install -y \
 pip install docker-compose
 
 # set up Docker APT repository and install docker-engine package
-curl -sSL https://get.docker.com | /bin/sh
+apt-get install -y \
+  --no-install-recommends \
+  docker-ce
 
 echo "Installing rpi-serial-console script"
 wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -1,12 +1,16 @@
 require 'spec_helper'
 
 describe package('docker-engine') do
+  it { should_not be_installed }
+end
+
+describe package('docker-ce') do
   it { should be_installed }
 end
 
-describe command('dpkg -l docker-engine') do
-  its(:stdout) { should match /ii  docker-engine/ }
-  its(:stdout) { should match /17.05.0~ce-0~raspbian-jessie/ }
+describe command('dpkg -l docker-ce') do
+  its(:stdout) { should match /ii  docker-ce/ }
+  its(:stdout) { should match /17.06.0~ce-0~debian/ }
   its(:exit_status) { should eq 0 }
 end
 
@@ -79,13 +83,13 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 17.05.0-ce, build/ }
+  its(:stdout) { should match /Docker version 17.06.0-ce, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:      17.05.0-ce. API version:  1.29/m }
-  its(:stdout) { should match /Server:. Version:      17.05.0-ce. API version:  1.29/m }
+  its(:stdout) { should match /Client:. Version:      17.06.0-ce. API version:  1.30/m }
+  its(:stdout) { should match /Server:. Version:      17.06.0-ce. API version:  1.30/m }
   its(:exit_status) { should eq 0 }
 end
 


### PR DESCRIPTION
Update to Docker CE 17.06 edge channel

Caveats: Does not work with Raspberry Pi 1/Zero/Zero W as docker engine is compiled for ARMv7 only.
