### PR TITLE
Use new ubuntu image and just export docker host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ vagrant:
 	vagrant up
 
 docker-setup: vagrant
-	export DOCKER_HOST=tcp://127.0.0.1:2376
+	export DOCKER_HOST=tcp://127.0.0.1:2375
 
 test-integration: test-integration-image test-integration-docker
 

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,6 @@ test:
 shellcheck: build
 	VERSION=dirty docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
 
-vagrant:
-	vagrant up
-
-docker-setup: vagrant
-	export DOCKER_HOST=tcp://127.0.0.1:2375
-
 test-integration: test-integration-image test-integration-docker
 
 test-integration-image:

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,8 @@ shellcheck: build
 vagrant:
 	vagrant up
 
-docker-machine: vagrant
-	docker-machine create -d generic \
-	  --generic-ssh-user $(shell vagrant ssh-config | grep ' User ' | cut -d ' ' -f 4) \
-	  --generic-ssh-key $(shell vagrant ssh-config | grep IdentityFile | cut -d ' ' -f 4) \
-	  --generic-ip-address $(shell vagrant ssh-config | grep HostName | cut -d ' ' -f 4) \
-	  --generic-ssh-port $(shell vagrant ssh-config | grep Port | cut -d ' ' -f 4) \
-	  image-builder-rpi
+docker-setup: vagrant
+	export DOCKER_HOST=tcp://127.0.0.1:2376
 
 test-integration: test-integration-image test-integration-docker
 

--- a/README.md
+++ b/README.md
@@ -25,22 +25,25 @@ You can build the SD card image locally with Vagrant.
 
 ### Setting up build environment
 
-Make sure you have [vagrant](https://docs.vagrantup.com/v2/installation/) and [docker-machine](https://docs.docker.com/machine/install-machine/) installed.
-Then run the following command to create the Vagrant box and the Docker Machine
-connection. The Vagrant box is needed as a vanilla boot2docker VM is not able to
-run guestfish inside. Use `export VAGRANT_DEFAULT_PROVIDER=virtualbox` to
-strictly create a VirtualBox VM.
+Make sure you have [vagrant](https://docs.vagrantup.com/v2/installation/) installed.
+Then run the following command to create the Vagrant box and use the Vagrant Docker
+daemon. The Vagrant box is needed to run guestfish inside.
+Use `export VAGRANT_DEFAULT_PROVIDER=virtualbox` to strictly create a VirtualBox VM.
 
 ```bash
-make docker-machine
+make docker-setup
 ```
 
-Now set the Docker environments to this new docker machine:
-
+Check you are using docker inside vagrant
 ```bash
-eval $(docker-machine env image-builder-rpi)
+docker info | grep 'Operating System'
+Operating System: Ubuntu 16.04.3 LTS
 ```
 
+If not, export docker host
+```bash
+export DOCKER_HOST=tcp://127.0.0.1:2376
+```
 ### Build the SD card image
 
 From here you can just make the SD card image. The output will be written and

--- a/README.md
+++ b/README.md
@@ -30,20 +30,22 @@ Then run the following command to create the Vagrant box and use the Vagrant Doc
 daemon. The Vagrant box is needed to run guestfish inside.
 Use `export VAGRANT_DEFAULT_PROVIDER=virtualbox` to strictly create a VirtualBox VM.
 
+Start vagrant box
 ```bash
-make docker-setup
+vagrant up
 ```
 
-Check you are using docker inside vagrant
+Export docker host
+```bash
+export DOCKER_HOST=tcp://127.0.0.1:2375
+```
+
+Check you are using docker from inside vagrant
 ```bash
 docker info | grep 'Operating System'
 Operating System: Ubuntu 16.04.3 LTS
 ```
 
-If not, export docker host
-```bash
-export DOCKER_HOST=tcp://127.0.0.1:2375
-```
 ### Build the SD card image
 
 From here you can just make the SD card image. The output will be written and

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Operating System: Ubuntu 16.04.3 LTS
 
 If not, export docker host
 ```bash
-export DOCKER_HOST=tcp://127.0.0.1:2376
+export DOCKER_HOST=tcp://127.0.0.1:2375
 ```
 ### Build the SD card image
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
 
-  config.vm.network "forwarded_port", guest: 2376, host: 2376, auto_correct: true
+  config.vm.network "forwarded_port", guest: 2375, host: 2375, auto_correct: true
   config.vm.synced_folder ".", "#{`pwd`.chomp}"
 
   config.vm.provider "vmware_fusion" do |v|
@@ -20,24 +20,27 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
-     sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-     echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
-     sudo apt-get update
-     sudo apt-get install -y linux-image-extra-$(uname -r)
-     sudo mkdir -p /etc/systemd/system/docker.service.d
-     # https://docs.docker.com/engine/admin/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts
- echo "
-[Service]
+    sudo apt-get update
+    sudo apt-get install -y \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+      stable"
+    sudo apt-get update
+    sudo apt-get install docker-ce -y
+    mkdir -p /etc/systemd/system/docker.service.d/
+    # https://docs.docker.com/engine/admin/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts
+    echo "[Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd" > /etc/systemd/system/docker.service.d/docker.conf
-     sudo apt-get install -y docker.io
- echo '
- {
- "hosts": ["tcp://0.0.0.0:2376"]
- }
- ' > /etc/docker/daemon.json
+    echo '{ "hosts": ["tcp://0.0.0.0:2375"] }' > /etc/docker/daemon.json
      sudo systemctl daemon-reload
      sudo systemctl enable docker
-     sudo systemctl start docker
+     sudo systemctl restart docker
   SHELL
 end


### PR DESCRIPTION
This PR fixes #205 by using `ubuntu/xenial64` box and also deprecates the use of docker-machine in favor of just using vagrant box docker to build images.