### PR TITLE
Fix duplicate IP address for eth0

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -206,12 +206,16 @@ apt-get install -y \
 apt-get install -y \
   cloud-init
 
-# Fix package mirrors
+# Fix cloud-init package mirrors
 sed -i '/disable_root: true/a apt_preserve_sources_list: true' /etc/cloud/cloud.cfg
 
+# Link cloud-init config to VFAT /boot partition
 mkdir -p /var/lib/cloud/seed/nocloud-net
 ln -s /boot/user-data /var/lib/cloud/seed/nocloud-net/user-data
 ln -s /boot/meta-data /var/lib/cloud/seed/nocloud-net/meta-data
+
+# Fix duplicate IP address for eth0, remove file from os-rootfs
+rm -f /etc/network/interfaces.d/eth0
 
 # install docker-machine
 curl -sSL -o /usr/local/bin/docker-machine "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"

--- a/builder/test-integration/spec/hypriotos-image/base/network_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/network_spec.rb
@@ -1,0 +1,4 @@
+
+describe file('/etc/network/interfaces.d/eth0') do
+  it { should_not be_file }
+end


### PR DESCRIPTION
~Disable cloud-init network config, the /etc/network/interfaces.d/eth0 is already there.~
Update: The problem also exists if clout-init's network config is disabled.

We have to remove the /etc/network/interfaces.d/eth0 to fix the duplicate IP address for eth0.

Fixes #223 