### PR TITLE
Set useradd default shell to bash

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -178,6 +178,9 @@ proc /proc proc defaults 0 0
 /dev/mmcblk0p2 / ext4 defaults,noatime 0 1
 " > /etc/fstab
 
+# Fix default shell for new users created with useradd
+sed -i 's,SHELL=/bin/sh,SHELL=/bin/bash,' /etc/default/useradd
+
 # as the Pi does not have a hardware clock we need a fake one
 apt-get install -y \
   --no-install-recommends \

--- a/builder/test-integration/spec/hypriotos-image/base/users_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/users_spec.rb
@@ -49,3 +49,9 @@ describe file('/home/pirate/.bash_prompt') do
   it { should be_mode 644 }
   it { should be_owned_by 'pirate' }
 end
+
+describe file('/etc/default/useradd') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  its(:content) { should contain /SHELL=\/bin\/bash/ }
+end


### PR DESCRIPTION
`useradd abc` creates a new user but with `/bin/sh` as default shell. Set the default to `/bin/bash`

Fixes #150 
