### PR TITLE
Remove Schatzkiste

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -101,9 +101,6 @@ get_gpg "${PACKAGECLOUD_FPR}" "${PACKAGECLOUD_KEY_URL}"
 
 echo 'deb https://packagecloud.io/Hypriot/rpi/debian/ stretch main' > /etc/apt/sources.list.d/hypriot.list
 
-# set up hypriot schatzkiste repository for generic packages
-echo 'deb https://packagecloud.io/Hypriot/Schatzkiste/debian/ stretch main' >> /etc/apt/sources.list.d/hypriot.list
-
 # set up Docker CE repository
 DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg

--- a/builder/files/etc/apt/preferences.d/hypriot
+++ b/builder/files/etc/apt/preferences.d/hypriot
@@ -1,5 +1,5 @@
 # ensure that only Hypriot kernel packages get installed
 
 Package: raspberrypi-kernel*
-Pin: origin packagecloud.io/hypriot/schatzkiste
+Pin: origin packagecloud.io/hypriot/rpi
 Pin-Priority: 1001

--- a/builder/test-integration/spec/hypriotos-image/hypriot-list_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/hypriot-list_spec.rb
@@ -4,7 +4,7 @@ describe file('/etc/apt/sources.list.d/hypriot.list') do
   it { should be_file }
   it { should be_mode 644 }
   it { should be_owned_by 'root' }
-  it { should contain 'deb https://packagecloud.io/Hypriot/Schatzkiste/debian/ stretch main' }
+  it { should contain 'deb https://packagecloud.io/Hypriot/rpi/debian/ stretch main' }
 end
 
 describe package('apt-transport-https') do


### PR DESCRIPTION
Remove https://packagecloud.io/Hypriot/Schatzkiste as we no longer need packages from there.
* docker-compose is installed with pip
* docker-machine is available as binary from upstream
