### PR TITLE
Add instance-id to meta-data

### DIFF
--- a/builder/files/boot/meta-data
+++ b/builder/files/boot/meta-data
@@ -1,0 +1,1 @@
+instance-id: pirate001

--- a/builder/test-integration/spec/hypriotos-image/cloud-init_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cloud-init_spec.rb
@@ -11,6 +11,7 @@ end
 
 describe file('/boot/meta-data') do
   it { should be_file }
+  its(:content) { should match /instance-id: / }
 end
 
 describe file('/var/lib/cloud/scripts/per-once/regenerate-machine-id') do


### PR DESCRIPTION
Add an `instance-id:` to meta-data file to resolve cloud-init error messages during a reboot.

Add a fixed instance-id is fine here as we do not use network to fetch cloud-init configs.

Fixes #232 