### PR TITLE
Update os-rootfs v2.0.1

### DIFF
--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -7,7 +7,7 @@ describe file('/etc/os-release') do
   it { should be_owned_by 'root' }
   its(:content) { should contain /ID=raspbian/ }
   its(:content) { should match /HYPRIOT_OS="HypriotOS\/armhf"/ }
-  its(:content) { should match /HYPRIOT_OS_VERSION="v2.0.0"/ }
+  its(:content) { should match /HYPRIOT_OS_VERSION="v2.0.1"/ }
   its(:content) { should match /HYPRIOT_DEVICE="Raspberry Pi"/ }
   its(:content) { should match /HYPRIOT_IMAGE_VERSION=/ }
 end

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -36,8 +36,8 @@ describe "Root filesystem" do
     expect(stdout).to contain('^HYPRIOT_DEVICE="Raspberry Pi"$')
   end
 
-  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v2.0.0\"'" do
-    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v2.0.0"$')
+  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v2.0.1\"'" do
+    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v2.0.1"$')
   end
 
   if ENV.fetch('CIRCLE_TAG','') != ''

--- a/versions.config
+++ b/versions.config
@@ -1,6 +1,6 @@
 # config vars for the root file system
-HYPRIOT_OS_VERSION="v2.0.0"
-ROOTFS_TAR_CHECKSUM="934a76f3af960bef4dc9e5b81c799bcfb449dd3474801f5f732e0577dbdcc1e8"
+HYPRIOT_OS_VERSION="v2.0.1"
+ROOTFS_TAR_CHECKSUM="d1e7e6d48a25b4a206c5df99ecb8815388ec6945e4f97e78413d5a80778d4137"
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"


### PR DESCRIPTION
Bringing https://github.com/hypriot/os-rootfs/pull/67 into this image to fix CircleCI builds.
