### PR TITLE
support cloud-init network-config

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -213,9 +213,23 @@ sed -i '/disable_root: true/a apt_preserve_sources_list: true' /etc/cloud/cloud.
 mkdir -p /var/lib/cloud/seed/nocloud-net
 ln -s /boot/user-data /var/lib/cloud/seed/nocloud-net/user-data
 ln -s /boot/meta-data /var/lib/cloud/seed/nocloud-net/meta-data
+ln -s /boot/network-config /var/lib/cloud/seed/nocloud-net/network-config
 
 # Fix duplicate IP address for eth0, remove file from os-rootfs
 rm -f /etc/network/interfaces.d/eth0
+
+# Disable dhcpcd - it has a conflict with cloud-init network config
+systemctl mask dhcpcd
+
+# Fix /etc/network/interfaces so the cloud-init network config is used
+echo "source /etc/network/interfaces.d/*" > /etc/network/interfaces
+
+# Install resolvconf ...
+apt-get install -y \
+  resolvconf
+
+# and disable systemd-resolved - it doesn't work with cloud-init network config
+systemctl mask systemd-resolved
 
 # install docker-machine
 curl -sSL -o /usr/local/bin/docker-machine "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"

--- a/builder/files/boot/network-config
+++ b/builder/files/boot/network-config
@@ -1,0 +1,6 @@
+version: 1
+config:
+  - type: physical
+    name: eth0
+    subnets:
+      - type: dhcp


### PR DESCRIPTION
This adds basic support for a cloud-init [`network-config` file](https://cloudinit.readthedocs.io/en/18.2/topics/network-config-format-v1.html).

network-config can be used for advanced network configuration, such as VLANs, which can't be configured using the default `dhcpcd`.
The provided default results in the same config as without this change, dhcp for eth0 (plus it won't have any effect because of the bug described below).

To make this work, a few additional steps are needed:

- cloud-init creates the file `/etc/network/interfaces.d/50-cloud-init.cfg`. The intent is that `ifup` etc. should pick this up. Unfortunately they won't, because according to the man page, files in include folder must match the regex `^[a-zA-Z0-9_-]+$.` - so it has to be renamed, or `/etc/network/interfaces` has to be [updated](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867921)
- By default, `dhcpcd` tries to manage all network interfaces, so there will be a conflict when `ifup` attempts to configure the same interfaces (it will probably do nothing). The workaround is to disable `dhcpcd` to manage all interfaces the old-fashioned way.

Add the following to `user-data` to make this work:

```
runcmd:
  - 'mv /etc/network/interfaces.d/50-cloud-init.cfg /etc/network/interfaces.d/50-cloud-init'
  - 'systemctl disable dhcpcd'

power_state:
  mode: reboot
```

I know this is not very elegant yet. Disabling `dhcpcd` by default would get rid of one of the extra steps above, but then there would still be the bug which results in the "wrong" filename.
Let me know if you have any ideas on how to improve this 😄 