### PR TITLE
Improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 *.img.zip
 *.tar.gz
 .vagrant/
+/*.log
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.img.zip
 *.tar.gz
 .vagrant/
+/*.log
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM hypriot/image-builder:latest
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    binfmt-support \
-    qemu \
-    qemu-user-static \
-    --no-install-recommends && \
+RUN set -euxo pipefail; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y binfmt-support qemu qemu-user-static --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
 COPY builder/ /builder/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hypriot/image-builder:latest
 
-RUN set -euxo pipefail; \
+RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM hypriot/image-builder:latest
 RUN set -euxo pipefail; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
-    apt-get install -y binfmt-support qemu qemu-user-static --no-install-recommends; \
+    apt-get install -y --no-install-recommends \
+        binfmt-support \
+        qemu \
+        qemu-user-static; \
     rm -rf /var/lib/apt/lists/*
 
 COPY builder/ /builder/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ sd-image: build
 	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi
 
 shell: build
-	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi bash
+	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -v $(shell pwd)/builder:/builder -e CIRCLE_TAG -e VERSION image-builder-rpi bash
 
 test:
 	VERSION=dirty docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi bash -c "unzip /workspace/hypriotos-rpi-dirty.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,8 +36,8 @@ Vagrant.configure(2) do |config|
     sudo apt-get install -y \
       apt-transport-https \
       ca-certificates \
-      software-properties-common \
-      docker-ce
+      docker-ce \
+      software-properties-common
 
     mkdir -p /etc/systemd/system/docker.service.d/
     # https://docs.docker.com/engine/admin/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,27 +20,36 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
+    set -euxo pipefail
+
+    export LANGUAGE=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+    sudo locale-gen en_US.UTF-8
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7EA0A9C3F273FCD8
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
     sudo apt-get update
     sudo apt-get install -y \
       apt-transport-https \
       ca-certificates \
-      curl \
-      software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
-    sudo apt-get update
-    sudo apt-get install docker-ce -y
+      software-properties-common \
+      docker-ce
+
     mkdir -p /etc/systemd/system/docker.service.d/
     # https://docs.docker.com/engine/admin/#troubleshoot-conflicts-between-the-daemonjson-and-startup-scripts
     echo "[Service]
 ExecStart=
 ExecStart=/usr/bin/dockerd" > /etc/systemd/system/docker.service.d/docker.conf
+
     echo '{ "hosts": ["tcp://0.0.0.0:2375"] }' > /etc/docker/daemon.json
-     sudo systemctl daemon-reload
-     sudo systemctl enable docker
-     sudo systemctl restart docker
+    sudo systemctl daemon-reload
+    sudo systemctl enable docker
+    sudo systemctl restart docker
+
+    echo "Done!"
   SHELL
 end

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -24,11 +24,7 @@ ROOTFS_TAR="rootfs-armhf-raspbian-${HYPRIOT_OS_VERSION}.tar.gz"
 ROOTFS_TAR_PATH="${BUILD_RESULT_PATH}/${ROOTFS_TAR}"
 
 # Show CIRCLE_TAG in Circle builds
-if [[ -z ${CIRCLE_TAG+x} ]]; then
-    echo "CIRCLE_TAG NOT SET"
-else
-    echo "CIRCLE_TAG=${CIRCLE_TAG}"
-fi
+echo CIRCLE_TAG="${CIRCLE_TAG:-}"
 
 # name of the sd-image we gonna create
 HYPRIOT_IMAGE_VERSION=${VERSION:="dirty"}
@@ -121,7 +117,7 @@ _EOF_
 umask 0000
 
 # compress image
-zip "${BUILD_RESULT_PATH}/${HYPRIOT_IMAGE_NAME}.zip" "${HYPRIOT_IMAGE_NAME}"
+zip "${BUILD_RESULT_PATH}/${HYPRIOT_IMAGE_NAME}.zip" "/${HYPRIOT_IMAGE_NAME}"
 cd ${BUILD_RESULT_PATH} && sha256sum "${HYPRIOT_IMAGE_NAME}.zip" > "${HYPRIOT_IMAGE_NAME}.zip.sha256" && cd -
 
 # test sd-image that we have built

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,5 +1,7 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+
+set -euxo pipefail
+
 # This script should be run only inside of a Docker container
 if [ ! -f /.dockerenv ]; then
   echo "ERROR: script works only in a Docker container!"
@@ -29,8 +31,16 @@ HYPRIOT_IMAGE_VERSION=${VERSION:="dirty"}
 HYPRIOT_IMAGE_NAME="hypriotos-rpi-${HYPRIOT_IMAGE_VERSION}.img"
 export HYPRIOT_IMAGE_VERSION
 
+# ensure no paths are mounted
+mountpoint -q -- "${BUILD_PATH}/dev/pts" && umount -l ${BUILD_PATH}/dev/pts
+mountpoint -q -- "${BUILD_PATH}/dev" && umount -l ${BUILD_PATH}/dev
+mountpoint -q -- "${BUILD_PATH}/proc" && umount -l ${BUILD_PATH}/proc
+mountpoint -q -- "${BUILD_PATH}/sys" && umount -l ${BUILD_PATH}/sys
+
 # create build directory for assembling our image filesystem
 rm -rf ${BUILD_PATH}
+
+# create build directory for assembling our image filesystem
 mkdir ${BUILD_PATH}
 
 # download our base root file system

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -24,7 +24,11 @@ ROOTFS_TAR="rootfs-armhf-raspbian-${HYPRIOT_OS_VERSION}.tar.gz"
 ROOTFS_TAR_PATH="${BUILD_RESULT_PATH}/${ROOTFS_TAR}"
 
 # Show CIRCLE_TAG in Circle builds
-echo CIRCLE_TAG="${CIRCLE_TAG}"
+if [[ -z ${CIRCLE_TAG+x} ]]; then
+    echo "CIRCLE_TAG NOT SET"
+else
+    echo "CIRCLE_TAG=${CIRCLE_TAG}"
+fi
 
 # name of the sd-image we gonna create
 HYPRIOT_IMAGE_VERSION=${VERSION:="dirty"}

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ex
+
+set -euxo pipefail
 
 KEYSERVER="ha.pool.sks-keyservers.net"
 
@@ -94,23 +95,25 @@ export DEST
 mkdir -p "$(dirname "${DEST}")"
 echo "nameserver 8.8.8.8" > "${DEST}"
 
+RELEASE="stretch" # todo ideally this should be retrieved from a command like lsb_release, but it is not installed.
+
 # set up hypriot rpi repository for rpi specific kernel- and firmware-packages
 PACKAGECLOUD_FPR=418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
 PACKAGECLOUD_KEY_URL=https://packagecloud.io/gpg.key
 get_gpg "${PACKAGECLOUD_FPR}" "${PACKAGECLOUD_KEY_URL}"
-echo 'deb https://packagecloud.io/Hypriot/rpi/debian/ $(lsb_release -cs) main' > /etc/apt/sources.list.d/hypriot.list
+echo "deb https://packagecloud.io/Hypriot/rpi/debian/ ${RELEASE} main" > /etc/apt/sources.list.d/hypriot.list
 
 # set up Docker CE repository
 DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
 get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
-echo "deb [arch=armhf] https://download.docker.com/linux/raspbian $(lsb_release -cs) ${DOCKER_CHANNEL}" > /etc/apt/sources.list.d/docker.list
+echo "deb [arch=armhf] https://download.docker.com/linux/raspbian ${RELEASE} ${DOCKER_CHANNEL}" > /etc/apt/sources.list.d/docker.list
 
 
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E
 RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
 get_gpg "${RPI_ORG_FPR}" "${RPI_ORG_KEY_URL}"
-echo 'deb http://archive.raspberrypi.org/debian $(lsb_release -cs) main' > /etc/apt/sources.list.d/raspberrypi.list
+echo "deb http://archive.raspberrypi.org/debian ${RELEASE} main" > /etc/apt/sources.list.d/raspberrypi.list
 
 # reload package sources
 apt-get update

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -2,92 +2,9 @@
 
 set -euxo pipefail
 
-KEYSERVER="ha.pool.sks-keyservers.net"
-
-function clean_print(){
-  local fingerprint="${2}"
-  local func="${1}"
-
-  nospaces=${fingerprint//[:space:]/}
-  tolowercase=${nospaces,,}
-  KEYID_long=${tolowercase:(-16)}
-  KEYID_short=${tolowercase:(-8)}
-  if [[ "${func}" == "fpr" ]]; then
-    echo "${tolowercase}"
-  elif [[ "${func}" == "long" ]]; then
-    echo "${KEYID_long}"
-  elif [[ "${func}" == "short" ]]; then
-    echo "${KEYID_short}"
-  elif [[ "${func}" == "print" ]]; then
-    if [[ "${fingerprint}" != "${nospaces}" ]]; then
-      printf "%-10s %50s\n" fpr: "${fingerprint}"
-    fi
-    # if [[ "${nospaces}" != "${tolowercase}" ]]; then
-    #   printf "%-10s %50s\n" nospaces: $nospaces
-    # fi
-    if [[ "${tolowercase}" != "${KEYID_long}" ]]; then
-      printf "%-10s %50s\n" lower: "${tolowercase}"
-    fi
-    printf "%-10s %50s\n" long: "${KEYID_long}"
-    printf "%-10s %50s\n" short: "${KEYID_short}"
-    echo ""
-  else
-    echo "usage: function {print|fpr|long|short} GPGKEY"
-  fi
-}
-
-
-function get_gpg(){
-  GPG_KEY="${1}"
-  KEY_URL="${2}"
-
-  clean_print print "${GPG_KEY}"
-  GPG_KEY=$(clean_print fpr "${GPG_KEY}")
-
-  if [[ "${KEY_URL}" =~ ^https?://* ]]; then
-    echo "loading key from url"
-    KEY_FILE=temp.gpg.key
-    wget -q -O "${KEY_FILE}" "${KEY_URL}"
-  elif [[ -z "${KEY_URL}" ]]; then
-    echo "no source given try to load from key server"
-#    gpg --keyserver "${KEYSERVER}" --recv-keys "${GPG_KEY}"
-    apt-key adv --keyserver "${KEYSERVER}" --recv-keys "${GPG_KEY}"
-    return $?
-  else
-    echo "keyfile given"
-    KEY_FILE="${KEY_URL}"
-  fi
-
-  FINGERPRINT_OF_FILE=$(gpg --with-fingerprint --with-colons "${KEY_FILE}" | grep fpr | rev |cut -d: -f2 | rev)
-
-  if [[ ${#GPG_KEY} -eq 16 ]]; then
-    echo "compare long keyid"
-    CHECK=$(clean_print long "${FINGERPRINT_OF_FILE}")
-  elif [[ ${#GPG_KEY} -eq 8 ]]; then
-    echo "compare short keyid"
-    CHECK=$(clean_print short "${FINGERPRINT_OF_FILE}")
-  else
-    echo "compare fingerprint"
-    CHECK=$(clean_print fpr "${FINGERPRINT_OF_FILE}")
-  fi
-
-  if [[ "${GPG_KEY}" == "${CHECK}" ]]; then
-    echo "key OK add to apt"
-    apt-key add "${KEY_FILE}"
-    rm -f "${KEY_FILE}"
-    return 0
-  else
-    echo "key invalid"
-    exit 1
-  fi
-}
-
-## examples:
-# clean_print {print|fpr|long|short} {GPGKEYID|FINGERPRINT}
-# get_gpg {GPGKEYID|FINGERPRINT} [URL|FILE]
-
 # device specific settings
 HYPRIOT_DEVICE="Raspberry Pi"
+RELEASE="stretch" # todo ideally this should be retrieved from a command like lsb_release, but it is installed later.
 
 # set up /etc/resolv.conf
 DEST=$(readlink -m /etc/resolv.conf)
@@ -95,24 +12,20 @@ export DEST
 mkdir -p "$(dirname "${DEST}")"
 echo "nameserver 8.8.8.8" > "${DEST}"
 
-RELEASE="stretch" # todo ideally this should be retrieved from a command like lsb_release, but it is not installed.
+export DEBIAN_FRONTEND=noninteractive
+
+# Install dirmngr to allow downloading apt keys from keyserver
+apt-get update && apt-get install -y dirmngr
 
 # set up hypriot rpi repository for rpi specific kernel- and firmware-packages
-PACKAGECLOUD_FPR=418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
-PACKAGECLOUD_KEY_URL=https://packagecloud.io/gpg.key
-get_gpg "${PACKAGECLOUD_FPR}" "${PACKAGECLOUD_KEY_URL}"
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2E73424D59097AB
 echo "deb https://packagecloud.io/Hypriot/rpi/debian/ ${RELEASE} main" > /etc/apt/sources.list.d/hypriot.list
 
 # set up Docker CE repository
-DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
-get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7EA0A9C3F273FCD8
 echo "deb [arch=armhf] https://download.docker.com/linux/raspbian ${RELEASE} ${DOCKER_CHANNEL}" > /etc/apt/sources.list.d/docker.list
 
-
-RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E
-RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
-get_gpg "${RPI_ORG_FPR}" "${RPI_ORG_KEY_URL}"
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 82B129927FA3303E
 echo "deb http://archive.raspberrypi.org/debian ${RELEASE} main" > /etc/apt/sources.list.d/raspberrypi.list
 
 # reload package sources
@@ -137,7 +50,7 @@ apt-get install -y \
   raspi-config
 
 # install special Docker enabled kernel
-if [ -z "${KERNEL_URL}" ]; then
+if [[ -z ${KERNEL_URL+x} ]]; then
   apt-get install -y \
     --no-install-recommends \
     "raspberrypi-kernel=${KERNEL_BUILD}"
@@ -177,12 +90,12 @@ proc /proc proc defaults 0 0
 " > /etc/fstab
 
 # as the Pi does not have a hardware clock we need a fake one
-apt-get install -y \
+apt-get install --assume-yes \
   --no-install-recommends \
   fake-hwclock
 
 # install packages for managing wireless interfaces
-apt-get install -y \
+apt-get install --assume-yes \
   --no-install-recommends \
   wpasupplicant \
   wireless-tools \
@@ -190,25 +103,34 @@ apt-get install -y \
   raspberrypi-net-mods
 
 # add firmware and packages for managing bluetooth devices
-apt-get install -y \
+apt-get install --assume-yes \
   --no-install-recommends \
   pi-bluetooth
 
 # ensure compatibility with Docker install.sh, so `raspbian` will be detected correctly
-apt-get install -y \
+apt-get install --assume-yes \
   --no-install-recommends \
   lsb-release \
   gettext
 
+# install python
+apt-get install --assume-yes \
+  --no-install-recommends \
+  python3-pip \
+  python3-setuptools
+
+ln -s /usr/bin/pip3 /usr/bin/pip
+ln -s /usr/bin/python3 /usr/bin/python
+pip install pip --upgrade # this requires logging out and logging back in to be able to simply use pip due to some bug.
+# Instead use "python -m pip <args>", after logout and back in, pip install etc should work.
+
 # install cloud-init
 apiBase="https://api.launchpad.net/1.0/ubuntu"
-latestVersion="$(curl -fsSL "$apiBase/+archive/primary?ws.op=getPublishedBinaries&pocket=Updates&binary_name=cloud-init&exact_match=true&status=Published&distro_arch_series=$apiBase/bionic/armhf" | python -mjson.tool | awk -F'"' '/binary_package_version/{print $4}')"
+# todo this url is ugly. need to find a nicer way of representing it.
+latestVersion="$(curl -fsSL "$apiBase/+archive/primary?ws.op=getPublishedBinaries&pocket=Updates&binary_name=cloud-init&exact_match=true&status=Published&distro_arch_series=$apiBase/bionic/armhf" | python3 -mjson.tool | awk -F'"' '/binary_package_version/{print $4}')"
 curl -fsSL "https://launchpad.net/ubuntu/+archive/primary/+files/cloud-init_${latestVersion}_all.deb" -o /tmp/cloud-init.deb
-dpkg -i /tmp/cloud-init.deb
-apt-get install -f -y
-
-# Fix cloud-init package mirrors
-sed -i '/disable_root: true/a apt_preserve_sources_list: true' /etc/cloud/cloud.cfg
+dpkg --install --force-depends --force-confold /tmp/cloud-init.deb
+apt-get install --fix-broken --assume-yes
 
 # Link cloud-init config to VFAT /boot partition
 mkdir -p /var/lib/cloud/seed/nocloud-net
@@ -218,37 +140,34 @@ ln -s /boot/meta-data /var/lib/cloud/seed/nocloud-net/meta-data
 # Fix duplicate IP address for eth0, remove file from os-rootfs
 rm -f /etc/network/interfaces.d/eth0
 
-# install docker-machine
-curl -sSL -o /usr/local/bin/docker-machine "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"
-chmod +x /usr/local/bin/docker-machine
-
-# install bash completion for Docker Machine
-curl -sSL "https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VERSION}/contrib/completion/bash/docker-machine.bash" -o /etc/bash_completion.d/docker-machine
-
-# install docker-compose
-apt-get install -y \
-  --no-install-recommends \
-  python
-curl -sSL https://bootstrap.pypa.io/get-pip.py | python
-pip install "docker-compose==${DOCKER_COMPOSE_VERSION}"
-
-# install bash completion for Docker Compose
-curl -sSL "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-
 # install docker-ce (w/ install-recommends)
-apt-get install -y --allow-downgrades \
+apt-get install --assume-yes --allow-downgrades \
   --no-install-recommends \
   "docker-ce=${DOCKER_CE_VERSION}"
 
-# install bash completion for Docker CLI
-curl -sSL https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker -o /etc/bash_completion.d/docker
+# install bash completion
+declare -A downloads=(
+    ["/etc/bash_completion.d/docker-machine"]="https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VERSION}/contrib/completion/bash/docker-machine.bash"
+    ["/etc/bash_completion.d/docker-compose"]="https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose"
+    ["/etc/bash_completion.d/docker"]="https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker"
+    ["/usr/local/bin/docker-machine"]="https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"
+    ["/usr/local/bin/rpi-serial-console"]="https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console"
+)
+for file in "${!downloads[@]}"; do
+    curl -fsSL "${downloads[$file]}" -o "$file"
+done
+chmod +x /usr/local/bin/docker-machine
+chmod +x /usr/local/bin/rpi-serial-console
 
-echo "Installing rpi-serial-console script"
-wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console
-chmod +x usr/local/bin/rpi-serial-console
+python -m pip install "docker-compose==${DOCKER_COMPOSE_VERSION}"
 
 # fix eth0 interface name
 ln -s /dev/null /etc/systemd/network/99-default.link
+
+# Neither are needed. Both can be fairly simply be installed using cloud-init or "apt-get update && apt-get install git/wget"
+sudo apt-get autoremove --purge \
+    git \
+    wget
 
 # cleanup APT cache and lists
 apt-get clean

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -125,10 +125,7 @@ pip install pip --upgrade # this requires logging out and logging back in to be 
 # Instead use "python -m pip <args>", after logout and back in, pip install etc should work.
 
 # install cloud-init
-apiBase="https://api.launchpad.net/1.0/ubuntu"
-# todo this url is ugly. need to find a nicer way of representing it.
-latestVersion="$(curl -fsSL "$apiBase/+archive/primary?ws.op=getPublishedBinaries&pocket=Updates&binary_name=cloud-init&exact_match=true&status=Published&distro_arch_series=$apiBase/bionic/armhf" | python3 -mjson.tool | awk -F'"' '/binary_package_version/{print $4}')"
-curl -fsSL "https://launchpad.net/ubuntu/+archive/primary/+files/cloud-init_${latestVersion}_all.deb" -o /tmp/cloud-init.deb
+curl -fsSL "https://launchpad.net/ubuntu/+archive/primary/+files/cloud-init_${CLOUD_INIT_VERSION}_all.deb" -o /tmp/cloud-init.deb
 dpkg --install --force-depends --force-confold /tmp/cloud-init.deb
 apt-get install --fix-broken --assume-yes
 

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -104,7 +104,7 @@ echo 'deb https://packagecloud.io/Hypriot/rpi/debian/ $(lsb_release -cs) main' >
 DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
 get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
-echo "deb [arch=armhf] https://download.docker.com/linux/raspbian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+echo "deb [arch=armhf] https://download.docker.com/linux/raspbian $(lsb_release -cs) ${DOCKER_CHANNEL}" > /etc/apt/sources.list.d/docker.list
 
 
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -164,11 +164,6 @@ python -m pip install "docker-compose==${DOCKER_COMPOSE_VERSION}"
 # fix eth0 interface name
 ln -s /dev/null /etc/systemd/network/99-default.link
 
-# Neither are needed. Both can be fairly simply be installed using cloud-init or "apt-get update && apt-get install git/wget"
-sudo apt-get autoremove --purge \
-    git \
-    wget
-
 # cleanup APT cache and lists
 apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -125,9 +125,10 @@ pip install pip --upgrade # this requires logging out and logging back in to be 
 # Instead use "python -m pip <args>", after logout and back in, pip install etc should work.
 
 # install cloud-init
-curl -fsSL "https://launchpad.net/ubuntu/+archive/primary/+files/cloud-init_${CLOUD_INIT_VERSION}_all.deb" -o /tmp/cloud-init.deb
-dpkg --install --force-depends --force-confold /tmp/cloud-init.deb
-apt-get install --fix-broken --assume-yes
+apt-get install --assume-yes cloud-init
+
+# Fix cloud-init package mirrors
+sed -i '/disable_root: true/a apt_preserve_sources_list: true' /etc/cloud/cloud.cfg
 
 # Link cloud-init config to VFAT /boot partition
 mkdir -p /var/lib/cloud/seed/nocloud-net

--- a/builder/files/etc/cloud/cloud.cfg
+++ b/builder/files/etc/cloud/cloud.cfg
@@ -1,0 +1,102 @@
+# The top level settings are used as module
+# and system configuration.
+
+# A set of users which may be applied and/or used by various modules
+# when a 'default' entry is found it will reference the 'default_user'
+# from the distro configuration specified below
+users:
+   - default
+
+# If this is set, 'root' will not be able to ssh in and they
+# will get a message to login instead as the default $user
+disable_root: true
+
+# This will cause the set+update hostname module to not operate (if true)
+preserve_hostname: false
+
+# Example datasource config
+# datasource:
+#    Ec2:
+#      metadata_urls: [ 'blah.com' ]
+#      timeout: 5 # (defaults to 50 seconds)
+#      max_wait: 10 # (defaults to 120 seconds)
+
+# The modules that run in the 'init' stage
+cloud_init_modules:
+ - migrator
+ - seed_random
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - disk_setup
+ - mounts
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - ca-certs
+ - rsyslog
+ - users-groups
+ - ssh
+
+# The modules that run in the 'config' stage
+cloud_config_modules:
+# Emit the cloud config ready event
+# this can be used by upstart jobs for 'start on cloud-config'.
+ - emit_upstart
+ - ssh-import-id
+ - locale
+ - set-passwords
+ - grub-dpkg
+ - apt-pipelining
+ - apt-configure
+ - ntp
+ - timezone
+ - disable-ec2-metadata
+ - runcmd
+ - byobu
+
+# The modules that run in the 'final' stage
+cloud_final_modules:
+ - package-update-upgrade-install
+ - fan
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - rightscale_userdata
+ - scripts-vendor
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+ - power-state-change
+
+# System and/or distro specific settings
+# (not accessible to handlers/transforms)
+system_info:
+   # This will affect which distro class gets used
+   distro: debian
+   # Default user name + that default users groups (if added/used)
+   default_user:
+     name: debian
+     lock_passwd: True
+     gecos: Debian
+     groups: [adm, audio, cdrom, dialout, dip, floppy, netdev, plugdev, sudo, video]
+     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+     shell: /bin/bash
+   # Other config here will be given to the distro class and/or path classes
+   paths:
+      cloud_dir: /var/lib/cloud/
+      templates_dir: /etc/cloud/templates/
+      upstart_dir: /etc/init/
+   package_mirrors:
+     - arches: [default]
+       failsafe:
+         primary: http://deb.debian.org/debian
+         security: http://security.debian.org/
+   ssh_svcname: ssh

--- a/builder/files/etc/cloud/cloud.cfg
+++ b/builder/files/etc/cloud/cloud.cfg
@@ -11,6 +11,8 @@ users:
 # will get a message to login instead as the default $user
 disable_root: true
 
+apt_preserve_sources_list: true
+
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false
 

--- a/versions.config
+++ b/versions.config
@@ -16,3 +16,5 @@ export DOCKER_CHANNEL="stable" # stable, test or edge
 export DOCKER_CE_VERSION="18.06.0~ce~3-0~raspbian"
 export DOCKER_COMPOSE_VERSION="1.21.1"
 export DOCKER_MACHINE_VERSION="0.14.0"
+
+export CLOUD_INIT_VERSION="18.3-9-g2e62cb8a-0ubuntu1~18.04.2"

--- a/versions.config
+++ b/versions.config
@@ -13,6 +13,6 @@ export KERNEL_BUILD="20180422-141901"
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 export KERNEL_VERSION="4.14.34"
 export DOCKER_CHANNEL="stable" # stable, test or edge
-export DOCKER_CE_VERSION="18.04.0~ce~3-0~raspbian"
+export DOCKER_CE_VERSION="18.06.0~ce~3-0~raspbian"
 export DOCKER_COMPOSE_VERSION="1.21.1"
 export DOCKER_MACHINE_VERSION="0.14.0"

--- a/versions.config
+++ b/versions.config
@@ -12,6 +12,7 @@ export KERNEL_BUILD="20180422-141901"
 # For testing a new kernel, use the CircleCI artifacts URL.
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 export KERNEL_VERSION="4.14.34"
+export DOCKER_CHANNEL="stable" # stable, test or edge
 export DOCKER_CE_VERSION="18.04.0~ce~3-0~raspbian"
 export DOCKER_COMPOSE_VERSION="1.21.1"
 export DOCKER_MACHINE_VERSION="0.14.0"


### PR DESCRIPTION
* Use keyserver.ubuntu.com to add keys for docker
  - [No piping GPG any more](https://www.tablix.org/~avian/blog/archives/2017/08/on_piping_curl_to_apt_key/)
* Ensure apt runs in non-interactive mode
* Gen locale to stop it from complaining
* Always use stable docker
* Replace deprecated `--force-yes` in favour of `--allow-downgrades`

Any feedback welcome. Happy to update the code.