### PR TITLE
Update docker-ce 18.09.0-ce-beta1

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -106,8 +106,7 @@ DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
 get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
 
-CHANNEL=edge # stable, test or edge
-echo "deb [arch=armhf] https://download.docker.com/linux/raspbian stretch $CHANNEL" > /etc/apt/sources.list.d/docker.list
+echo "deb [arch=armhf] https://download.docker.com/linux/raspbian stretch $DOCKER_CE_CHANNEL" > /etc/apt/sources.list.d/docker.list
 
 
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key

--- a/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe command('uname -r') do
-  its(:stdout) { should match /4.14.34(-v7)?+/ }
+  its(:stdout) { should match /4.14.70(-v7)?+/ }
   its(:exit_status) { should eq 0 }
 end
 
-describe file('/lib/modules/4.14.34-hypriotos+/kernel') do
+describe file('/lib/modules/4.14.70-hypriotos+/kernel') do
   it { should be_directory }
 end
 
-describe file('/lib/modules/4.14.34-hypriotos-v7+/kernel') do
+describe file('/lib/modules/4.14.70-hypriotos-v7+/kernel') do
   it { should be_directory }
 end

--- a/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
@@ -7,7 +7,7 @@ describe file('/usr/local/bin/docker-compose') do
 end
 
 describe command('docker-compose --version') do
-  its(:stdout) { should match /1.21.1/m }
+  its(:stdout) { should match /1.22.0/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
@@ -7,7 +7,7 @@ describe file('/usr/local/bin/docker-machine') do
 end
 
 describe command('docker-machine --version') do
-  its(:stdout) { should match /0.14.0/m }
+  its(:stdout) { should match /0.15.0/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -8,9 +8,13 @@ describe package('docker-ce') do
   it { should be_installed }
 end
 
+describe package('docker-ce-cli') do
+  it { should be_installed }
+end
+
 describe command('dpkg -l docker-ce') do
   its(:stdout) { should match /ii  docker-ce/ }
-  its(:stdout) { should match /18.04.0~ce~3-0~raspbian/ }
+  its(:stdout) { should match /3:18.09.0~ce~1.1.beta1-0~raspbian-stretch/ }
   its(:stdout) { should match /armhf/ }
   its(:exit_status) { should eq 0 }
 end
@@ -21,33 +25,20 @@ describe file('/usr/bin/docker') do
   it { should be_owned_by 'root' }
 end
 
-describe file('/usr/bin/docker-containerd') do
+
+describe package('containerd.io') do
+  it { should be_installed }
+end
+
+describe file('/usr/bin/containerd') do
   it { should be_file }
   it { should be_mode 755 }
   it { should be_owned_by 'root' }
 end
 
-describe file('/usr/bin/docker-containerd-ctr') do
+describe file('/usr/bin/containerd-shim') do
   it { should be_file }
   it { should be_mode 755 }
-  it { should be_owned_by 'root' }
-end
-
-describe file('/usr/bin/docker-containerd-shim') do
-  it { should be_file }
-  it { should be_mode 755 }
-  it { should be_owned_by 'root' }
-end
-
-describe file('/usr/bin/docker-runc') do
-  it { should be_file }
-  it { should be_mode 755 }
-  it { should be_owned_by 'root' }
-end
-
-describe file('/lib/systemd/system/docker.socket') do
-  it { should be_file }
-  it { should be_mode 644 }
   it { should be_owned_by 'root' }
 end
 
@@ -84,18 +75,18 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 18.04.0-ce, build/ }
+  its(:stdout) { should match /Docker version 18.09.0-ce-beta1, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:	18.04.0-ce. API version:	1.37/m }
-  its(:stdout) { should match /Server:. Engine:.  Version:	18.04.0-ce.  API version:	1.37/m }
+  its(:stdout) { should match /Client:. Version:           18.09.0-ce-beta1. API version:       1.39/m }
+  its(:stdout) { should match /Server:. Engine:.  Version:          18.09.0-ce-beta1.  API version:      1.39/m }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker info') do
-  its(:stdout) { should match /Storage Driver: overlay/ }
+  its(:stdout) { should match /Storage Driver: overlay2/ }
   its(:exit_status) { should eq 0 }
 end
 

--- a/versions.config
+++ b/versions.config
@@ -8,10 +8,11 @@ RAW_IMAGE_VERSION="v0.2.2"
 RAW_IMAGE_CHECKSUM="2fbeb13b7b0f2308dbd0d82780b54c33003ad43d145ff08498b25fb8bbe1c2c6"
 
 # specific versions of kernel/firmware and docker tools
-export KERNEL_BUILD="20180422-141901"
+export KERNEL_BUILD="20180922-053217"
 # For testing a new kernel, use the CircleCI artifacts URL.
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
-export KERNEL_VERSION="4.14.34"
-export DOCKER_CE_VERSION="18.04.0~ce~3-0~raspbian"
-export DOCKER_COMPOSE_VERSION="1.21.1"
-export DOCKER_MACHINE_VERSION="0.14.0"
+export KERNEL_VERSION="4.14.70"
+export DOCKER_CE_CHANNEL="test" # stable, test or edge
+export DOCKER_CE_VERSION="3:18.09.0~ce~1.1.beta1-0~raspbian-stretch"
+export DOCKER_COMPOSE_VERSION="1.22.0"
+export DOCKER_MACHINE_VERSION="0.15.0"


### PR DESCRIPTION
Time for some updates:

- Kernel 4.14.70 based on latest tag in raspberrypi/linux repo
- Docker CE 18.09.0-ce-beta1
- Docker Compose 1.22.0
- Docker Machine 0.15.0

new packages
- docker-ce-cli
- containerd.io
