### PR TITLE
Include ssh-import-id to enable cloud-unit module

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -202,7 +202,8 @@ apt-get install -y \
 
 # install cloud-init
 apt-get install -y \
-  cloud-init
+  cloud-init \
+  ssh-import-id
 
 # Fix cloud-init package mirrors
 sed -i '/disable_root: true/a apt_preserve_sources_list: true' /etc/cloud/cloud.cfg


### PR DESCRIPTION
The cloud-unit [ssh-import-id](https://cloudinit.readthedocs.io/en/0.7.9/topics/modules.html#ssh-import-id) module allows to import and update the authorized keys from Launchpad and Github.

This allows folks to use the public keys that are allowed to access GitHub to access their system as well.

```yaml
users:
  - name: bltavares
    ssh-import-id:
      - gh:bltavares
```

This commit installs [ssh-import-id](http://manpages.ubuntu.com/manpages/xenial/man1/ssh-import-id.1.html) as part of the image to avoid the current initialization error when the configuration is set:

```
ssh-import-id: command not found
```