### PR TITLE
Downgrade to 18.06.1 to support all RPi models

### DIFF
--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -14,7 +14,7 @@ end
 
 describe command('dpkg -l docker-ce') do
   its(:stdout) { should match /ii  docker-ce/ }
-  its(:stdout) { should match /5:18.09.0~3-0~raspbian-stretch/ }
+  its(:stdout) { should match /5:18.06.1~3-0~raspbian-stretch/ }
   its(:stdout) { should match /armhf/ }
   its(:exit_status) { should eq 0 }
 end
@@ -75,13 +75,13 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 18.09.0, build/ }
+  its(:stdout) { should match /Docker version 18.06.1, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:           18.09.0. API version:       1.39/m }
-  its(:stdout) { should match /Server: Docker Engine - Community. Engine:.  Version:          18.09.0.  API version:      1.39/m }
+  its(:stdout) { should match /Client:. Version:           18.06.1. API version:       1.39/m }
+  its(:stdout) { should match /Server: Docker Engine - Community. Engine:.  Version:          18.06.1.  API version:      1.39/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -9,12 +9,12 @@ describe package('docker-ce') do
 end
 
 describe package('docker-ce-cli') do
-  it { should be_installed }
+  it { should_not be_installed }
 end
 
 describe command('dpkg -l docker-ce') do
   its(:stdout) { should match /ii  docker-ce/ }
-  its(:stdout) { should match /5:18.06.1~3-0~raspbian-stretch/ }
+  its(:stdout) { should match /18.06.1~ce~3-0~raspbian/ }
   its(:stdout) { should match /armhf/ }
   its(:exit_status) { should eq 0 }
 end
@@ -75,13 +75,13 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 18.06.1, build/ }
+  its(:stdout) { should match /Docker version 18.06.1-ce, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:           18.06.1. API version:       1.39/m }
-  its(:stdout) { should match /Server: Docker Engine - Community. Engine:.  Version:          18.06.1.  API version:      1.39/m }
+  its(:stdout) { should match /Client:. Version:           18.06.1-ce. API version:       1.38/m }
+  its(:stdout) { should match /Server:. Engine:.  Version:          18.06.1-ce.  API version:      1.38/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/versions.config
+++ b/versions.config
@@ -13,6 +13,6 @@ export KERNEL_BUILD="1.20181112-1"
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 export KERNEL_VERSION="4.14.79"
 export DOCKER_CE_CHANNEL="stable" # stable, test or edge
-export DOCKER_CE_VERSION="5:18.09.0~3-0~raspbian-stretch"
+export DOCKER_CE_VERSION="5:18.06.1~3-0~raspbian-stretch"
 export DOCKER_COMPOSE_VERSION="1.23.2"
 export DOCKER_MACHINE_VERSION="0.16.0"

--- a/versions.config
+++ b/versions.config
@@ -13,6 +13,6 @@ export KERNEL_BUILD="1.20181112-1"
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 export KERNEL_VERSION="4.14.79"
 export DOCKER_CE_CHANNEL="stable" # stable, test or edge
-export DOCKER_CE_VERSION="5:18.06.1~3-0~raspbian-stretch"
+export DOCKER_CE_VERSION="18.06.1~ce~3-0~raspbian"
 export DOCKER_COMPOSE_VERSION="1.23.2"
 export DOCKER_MACHINE_VERSION="0.16.0"


### PR DESCRIPTION
Downgrade from 18.09.0 to 18.06.1 to support all Raspberry Pi models.

Fixes #271 