### PR TITLE
Support both USB and SD booting using PARTUUID mounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.img.zip.sha256
 *.img
 *.img.zip
+*.log
 *.tar.gz
 .vagrant/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && \
     binfmt-support \
     qemu \
     qemu-user-static \
+    xxd \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 

--- a/builder/files/usr/src/cloud-init/cc_resizefs.patch
+++ b/builder/files/usr/src/cloud-init/cc_resizefs.patch
@@ -1,0 +1,11 @@
+--- cc_resizefs.py	2019-04-10 11:22:50.000000000 -0400
++++ cc_resizefs.patched.py	2019-04-10 11:23:43.000000000 -0400
+@@ -86,6 +86,8 @@
+         return "/dev/disk/by-label/" + found[len("LABEL="):]
+     if found.startswith("UUID="):
+         return "/dev/disk/by-uuid/" + found[len("UUID="):]
++    if found.startswith("PARTUUID="):
++        return "/dev/disk/by-partuuid/" + found[len("PARTUUID="):]
+
+     return "/dev/" + found
+ 

--- a/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/cmdline_kernel_spec.rb
@@ -3,7 +3,7 @@ describe file('/boot/cmdline.txt') do
   it { should be_mode 755 }
   it { should be_owned_by 'root' }
   its(:content) { should match /dwc_otg.lpm_enable=0/ }
-  its(:content) { should match /root=\/dev\/mmcblk0p2/ }
+  its(:content) { should match /root=PARTUUID=[0-9a-z]{8}-02/ }
   its(:content) { should match /rootfstype=ext4/ }
   its(:content) { should match /cgroup_enable=memory/ }
   its(:content) { should match /cgroup_enable=cpuset/ }

--- a/builder/test/image_spec.rb
+++ b/builder/test/image_spec.rb
@@ -35,11 +35,11 @@ describe "SD card image" do
     let(:stdout) { run_mounted("cat /etc/fstab").stdout }
 
     it "has a vfat boot entry" do
-      expect(stdout).to contain('/dev/mmcblk0p1 /boot vfat')
+      expect(stdout).to match(/PARTUUID=[0-9a-z]{8}-01 \/boot vfat/)
     end
 
     it "has a ext4 root entry" do
-      expect(stdout).to contain('/dev/mmcblk0p2 / ext4')
+      expect(stdout).to match(/PARTUUID=[0-9a-z]{8}-02 \/ ext4/)
     end
   end
 end

--- a/versions.config
+++ b/versions.config
@@ -8,7 +8,7 @@ RAW_IMAGE_VERSION="v0.2.1"
 RAW_IMAGE_CHECKSUM="0fe529a329e0fe51fa0bff0aadf63f17b30f3db6b9fa882431fe51c1ae5f9302"
 
 # specific versions of kernel/firmware and docker tools
-export KERNEL_BUILD="1.20190215-1"
+export KERNEL_BUILD="1.20190401-1"
 # For testing a new kernel, use the CircleCI artifacts URL.
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 export KERNEL_VERSION="4.14.98"

--- a/versions.config
+++ b/versions.config
@@ -4,8 +4,8 @@ ROOTFS_TAR_CHECKSUM="d1e7e6d48a25b4a206c5df99ecb8815388ec6945e4f97e78413d5a80778
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"
-RAW_IMAGE_VERSION="v0.2.1"
-RAW_IMAGE_CHECKSUM="0fe529a329e0fe51fa0bff0aadf63f17b30f3db6b9fa882431fe51c1ae5f9302"
+RAW_IMAGE_VERSION="v0.3.1"
+RAW_IMAGE_CHECKSUM="ccff10498fb45fb76c6064988fb01b3543adfdb70ee7e5fb04b51885573684a6"
 
 # specific versions of kernel/firmware and docker tools
 export KERNEL_BUILD="1.20190401-1"


### PR DESCRIPTION
My goal with the PR is to make the hypriot RPI images agnostic to being booted from USB stick or SD card on a Pi 3B+ which supports either boot natively.  I took inspiration (and some code) from the Raspbian images which are also built in such a way that they can be USB or SDcard booted.

In my trial-and-error I discovered that cloud-init 0.7.9 has a bug in it which prevents the root partition from being resized when using PARTUUID partition references, which is why this PR also includes a very small patch to cloud-init to make this work.  Later versions of cloud-init have actually fixed this, but there are too many radical changes in the latest version of cloud-init to make it practical to include.

I have updated the tests in order to validate the PARTUUID references.  To test it out, simply flash the image onto both an SD card and a USB stick, then try both on a Pi 3B+, or a Pi 3 that has had the OTP usb boot update.

See discussion at https://github.com/hypriot/image-builder-rpi/issues/282