### PR TITLE
Removes Debian repos from cloud.cfg

### DIFF
--- a/builder/files/etc/cloud/cloud.cfg
+++ b/builder/files/etc/cloud/cloud.cfg
@@ -96,9 +96,4 @@ system_info:
       cloud_dir: /var/lib/cloud/
       templates_dir: /etc/cloud/templates/
       upstart_dir: /etc/init/
-   package_mirrors:
-     - arches: [default]
-       failsafe:
-         primary: http://deb.debian.org/debian
-         security: http://security.debian.org/
    ssh_svcname: ssh


### PR DESCRIPTION
Fixes #307 by removing the mentioned Debian Repos from cloud.cfg

Signed-off-by: Troy Fontaine <tfontaine@troyfontaine.com>