### PR TITLE
Make fake-hwclock run before fsck-root

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -210,7 +210,7 @@ ln -s /boot/fake-hwclock.data /etc/fake-hwclock.data
 mkdir -p /etc/systemd/system/fake-hwclock.service.d
 cat <<EOM |tee /etc/systemd/system/fake-hwclock.service.d/override.conf
 [Unit]
-After=boot.mount
+Before=systemd-fsck-root.service
 #Wants=boot.mount
 #Requires=boot.mount
 EOM


### PR DESCRIPTION
fsck is failing because of clock issues.

https://www.raspberrypi.org/forums/viewtopic.php?f=66&t=198937&p=1368234#p1368234

#351 