### PR TITLE
Added needed tools to compile bcrpyt

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -242,7 +242,8 @@ curl -sSL "https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VE
 # install docker-compose
 apt-get install -y \
   --no-install-recommends \
-  python3 python3-pip python3-setuptools
+  libc6-armel-cross python3-dev libffi-dev libssl-dev libc6-dev-armel-cross libncurses5-dev build-essential bison flex libssl-dev bc \
+  python3 python3-pip python3-setuptools gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
 pip3 install "docker-compose==${DOCKER_COMPOSE_VERSION}"
 


### PR DESCRIPTION
## Purpose

Fix all the recent versions.

Since the last release, [bcrypt](https://github.com/pyca/bcrypt) no longer releases a wheel for arm in their latest version.

Therefore, our builder has to build one, and since it is not equipped to do so, it dies.

## Approach

Added a couple of development packages.

This might not be the best place to solve the problem since those tools should not make it to the final product, certainly expecting feedback.

## Credit

This was solved by @sjawhar ([this guy](https://github.com/sjawhar))