### PR TITLE
added provisioner support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	docker build -t image-builder-rpi .
 
 sd-image: build
-	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi
+	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION -e PROVISIONER image-builder-rpi
 
 shell: build
-	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi bash
+	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION -e PROVISIONER image-builder-rpi bash
 
 test:
-	VERSION=dirty docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION image-builder-rpi bash -c "unzip /workspace/hypriotos-rpi-dirty.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
+	VERSION=dirty docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e CIRCLE_TAG -e VERSION -e PROVISIONER image-builder-rpi bash -c "/workspace/builder/run_tests.sh"
 
 shellcheck: build
 	VERSION=dirty docker run --rm -ti -v $(shell pwd):/workspace image-builder-rpi bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/var/lib/cloud/scripts/per-once/*'

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -94,19 +94,12 @@ export DEST
 mkdir -p "$(dirname "${DEST}")"
 echo "nameserver 8.8.8.8" > "${DEST}"
 
-# set up Docker CE repository
-DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
-get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
-
-echo "deb [arch=armhf] https://download.docker.com/linux/raspbian buster $DOCKER_CE_CHANNEL" > /etc/apt/sources.list.d/docker.list
-
-c_rehash
-
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
 get_gpg "${RPI_ORG_FPR}" "${RPI_ORG_KEY_URL}"
 
 echo 'deb http://archive.raspberrypi.org/debian/ buster main' | tee /etc/apt/sources.list.d/raspberrypi.list
+
+c_rehash
 
 # reload package sources
 apt-get update
@@ -232,31 +225,12 @@ apt-get install -y \
 # and disable systemd-resolved - it doesn't work with cloud-init network config
 systemctl mask systemd-resolved
 
-# install docker-machine
-curl -sSL -o /usr/local/bin/docker-machine "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"
-chmod +x /usr/local/bin/docker-machine
-
-# install bash completion for Docker Machine
-curl -sSL "https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VERSION}/contrib/completion/bash/docker-machine.bash" -o /etc/bash_completion.d/docker-machine
-
-# install docker-compose
-apt-get install -y \
-  --no-install-recommends \
-  python3 python3-pip python3-setuptools
-update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
-pip3 install "docker-compose==${DOCKER_COMPOSE_VERSION}"
-
-# install bash completion for Docker Compose
-curl -sSL "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
-
-# install docker-ce (w/ install-recommends)
-apt-get install -y --force-yes \
-  --no-install-recommends \
-  "docker-ce-cli=${DOCKER_CE_VERSION}" \
-  "docker-ce=${DOCKER_CE_VERSION}"
-
-# install bash completion for Docker CLI
-curl -sSL https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker -o /etc/bash_completion.d/docker
+# Execute the provisioner scripts to customize the base image install
+if [ -f /provisioner.sh ]
+then
+  export ARCH=arm64
+  /bin/sh /provisioner.sh
+fi
 
 echo "Installing rpi-serial-console script"
 wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console

--- a/builder/provisioners/docker.sh
+++ b/builder/provisioners/docker.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# set up Docker CE repository
+DOCKERREPO_FPR=9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
+get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
+
+echo "deb [arch=armhf] https://download.docker.com/linux/raspbian buster $DOCKER_CE_CHANNEL" > /etc/apt/sources.list.d/docker.list
+
+c_rehash
+
+apt-get update -y
+
+# install docker-machine
+curl -sSL -o /usr/local/bin/docker-machine "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-armhf"
+chmod +x /usr/local/bin/docker-machine
+
+# install bash completion for Docker Machine
+curl -sSL "https://raw.githubusercontent.com/docker/machine/v${DOCKER_MACHINE_VERSION}/contrib/completion/bash/docker-machine.bash" -o /etc/bash_completion.d/docker-machine
+
+# install docker-compose
+apt-get install -y \
+  --no-install-recommends \
+  python3 python3-pip python3-setuptools
+update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
+pip3 install "docker-compose==${DOCKER_COMPOSE_VERSION}"
+
+# install bash completion for Docker Compose
+curl -sSL "https://raw.githubusercontent.com/docker/compose/${DOCKER_COMPOSE_VERSION}/contrib/completion/bash/docker-compose" -o /etc/bash_completion.d/docker-compose
+
+# install docker-ce (w/ install-recommends)
+apt-get install -y --force-yes \
+  --no-install-recommends \
+  "docker-ce-cli=${DOCKER_CE_VERSION}" \
+  "docker-ce=${DOCKER_CE_VERSION}"
+
+# install bash completion for Docker CLI
+curl -sSL https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker -o /etc/bash_completion.d/docker

--- a/builder/run_tests.sh
+++ b/builder/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export PROVISIONER=${PROVISIONER:=docker}
+
+unzip "/workspace/hypriotos-rpi-${VERSION}-${PROVISIONER}.img.zip" && rspec --format documentation --color /workspace/builder/test/*_spec.rb

--- a/builder/test/spec_helper.rb
+++ b/builder/test/spec_helper.rb
@@ -2,7 +2,7 @@ require 'serverspec'
 set :backend, :exec
 
 def image_path
-  return "hypriotos-rpi-#{ENV['VERSION']}.img"
+  return "hypriotos-rpi-#{ENV['VERSION']}-#{ENV['PROVISIONER']}.img"
 end
 
 def run( cmd )


### PR DESCRIPTION
I wanted to know if the project would be interested in this change. I am testing a few different cluster variants and I wanted to take advantage of the Hypriot image but I wanted to swap out docker for k3s. To facilitate this, I broke out the docker installation into a provisioner folder and moved the installation code into this directory.

This change will let end-users add custom provisioners and set the provisioner by setting the PROVISIONER environment variable. 